### PR TITLE
[Bug Fix] local.sh: Permission denied

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -67,7 +67,7 @@ jobs:
         shell: bash
         timeout-minutes: 20
         run: |
-          ./local.sh
+          bash ./local.sh
 
       - uses: actions/create-github-app-token@v2
         id: app-token


### PR DESCRIPTION
The original version will give a
```
./local.sh: Permission denied
```

I made a small fix that should hopefully resolve the issue, though I'm not completely sure.